### PR TITLE
Natural string ordering for the parts of version strings

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
@@ -23,7 +23,7 @@ class VersionOrdering extends Ordering[Version] {
       case (Left(_), Right(_)) => -1
       case (Right(_), Left(_)) => 1
       case (Right(x), Right(y)) => x compareTo y
-    } find (0 !=)
+    } find (0 !=) orElse Some(a compareTo b)
   }
 
   private def compareNumericParts(a: List[Long], b: List[Long]): Option[Int] = (a, b) match {

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -47,7 +47,8 @@ class VersionSpec extends FreeSpec with ShouldMatchers {
         "1.33.7+build.11.e0f985a",
         "2.0.M5b",
         "2.0.M6-SNAP9",
-        "2.0.M6-SNAP23"
+        "2.0.M6-SNAP23",
+        "2.0.M6-SNAP23a"
       ).map(Version.apply)
       val pairs = v.tails.flatMap {
         case h :: t => t.map((h, _))


### PR DESCRIPTION
The problem was spotted at ScalaTest’s prerelease versions which are unusually numerous:
https://oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.10/maven-metadata.xml
With current lexicographic ordering, plugin suggests updating to SNAP9 instead of SNAP23.  
