### PR TITLE
Handle NumberFormatException for a number like part

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
@@ -6,12 +6,14 @@ class VersionOrdering extends Ordering[Version] {
 
   private val subParts = "(\\d+)?(\\D+)?".r
 
-  private def parsePart(s:String) = {
+  private def parsePart(s:String): Seq[Either[Int, String]] = try {
     subParts.findAllIn(s).matchData
       .flatMap { case Groups(num, str) => Seq(
         Option(num).map(_.toInt).map(Left.apply),
         Option(str).map(Right.apply))
-      }.flatten
+      }.flatten.toList
+  } catch {
+    case _: NumberFormatException => List(Right(s))
   }
 
   private def toOpt(x: Int): Option[Int] = if (x == 0) None else Some(x)

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -34,6 +34,7 @@ class VersionSpec extends FreeSpec with ShouldMatchers {
     "should be ordered according to the semantic versioning spec" in {
       val v = List(
         "invalid",
+        "1.0.0-20131213005945",
         "1.0.0-alpha",
         "1.0.0-alpha.1",
         "1.0.0-beta.2",


### PR DESCRIPTION
It failed to parse a number when it is too long. This patch treats such parts
as a string.
