### PR TITLE
sbt 0.13 build syntax upgrade + libraries upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,17 @@ version := "0.1.6-SNAPSHOT"
 
 scalacOptions := Seq("-deprecation", "-unchecked")
 
-libraryDependencies <++= (sbtVersion in sbtPlugin) { version =>
+def versions(sbtVersion: String) = {
   val V013 = """0\.13(?:\..*|)""".r
-  val (scalaz, scalatest) = version match {
-    case V013() => ("7.1.0-M4", "2.0.1-SNAP4")
-    case _ => ("7.0.5", "2.0.M6-SNAP3")
+  sbtVersion match {
+    case V013() => ("7.1.0-M6", "2.1.4-SNAP1")
+    case _      => ("7.0.6",    "2.1.4-SNAP1")
   }
+}
+
+libraryDependencies ++= {
+  val sbtV = (sbtVersion in sbtPlugin).value
+  val (scalaz, scalatest) = versions(sbtV)
   Seq(
     "org.scalaz"    %% "scalaz-concurrent" % scalaz    % "embedded",
     "org.scalatest" %% "scalatest"         % scalatest % "test")

--- a/project/SbtUpdatesBuild.scala
+++ b/project/SbtUpdatesBuild.scala
@@ -2,11 +2,10 @@ import sbt._
 
 object SbtUpdatesBuild extends Build {
 
-  val publishMinJar = TaskKey[File]("publish-min-jar")
-  val Embedded = config("embedded").hide
+  val Embedded = config("embedded") hide
 
   lazy val `sbt-updates` = project in file(".") settings(
     Project.defaultSettings ++
-    inConfig(Embedded)(Defaults.configSettings): _*
+      inConfig(Embedded)(Defaults.configSettings): _*
   ) configs Embedded
 }


### PR DESCRIPTION
The aim of the changes was to get rid of the old pre-sbt-0.13 syntax in the build. `publishLocal` worked fine for me.
