### PR TITLE
Add ability to exclude dependencies from update reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Tasks
 Settings
 ========
 * `dependencyUpdatesReportFile`: report file location, `target/dependency-updates.txt` by default.
+* `dependencyUpdatesExclusions`: filter matching dependencies that should be excluded from update reporting.
 * `dependencyUpdatesFailBuild`: `dependencyUpdates` task will fail a build if updates found.
 
 Example:

--- a/src/main/scala/com/timushev/sbt/updates/Reporter.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Reporter.scala
@@ -71,13 +71,15 @@ object Reporter {
     }
   }
 
-  def displayDependencyUpdates(project: ModuleID, dependencyUpdates: Map[ModuleID, SortedSet[Version]], failBuild: Boolean, out: TaskStreams[_]): Unit = {
-    out.log.info(dependencyUpdatesReport(project, dependencyUpdates))
-    if (failBuild && dependencyUpdates.nonEmpty) sys.error("Dependency updates found")
+  def displayDependencyUpdates(project: ModuleID, dependencyUpdates: Map[ModuleID, SortedSet[Version]], excluded: ModuleFilter, failBuild: Boolean, out: TaskStreams[_]): Unit = {
+    val nonExcluded = dependencyUpdates.filterKeys(moduleId => !excluded(moduleId))
+    out.log.info(dependencyUpdatesReport(project, nonExcluded))
+    if (failBuild && nonExcluded.nonEmpty) sys.error("Dependency updates found")
   }
 
-  def writeDependencyUpdatesReport(project: ModuleID, dependencyUpdates: Map[ModuleID, SortedSet[Version]], file: File, out: TaskStreams[_]): File = {
-    IO.write(file, dependencyUpdatesReport(project, dependencyUpdates) + "\n")
+  def writeDependencyUpdatesReport(project: ModuleID, dependencyUpdates: Map[ModuleID, SortedSet[Version]], excluded: ModuleFilter, file: File, out: TaskStreams[_]): File = {
+    val nonExcluded = dependencyUpdates.filterKeys(moduleId => !excluded(moduleId))
+    IO.write(file, dependencyUpdatesReport(project, nonExcluded) + "\n")
     out.log.info("Dependency update report written to %s" format file)
     file
   }

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.SortedSet
 
 trait UpdatesKeys {
   lazy val dependencyUpdatesReportFile = settingKey[File]("Dependency updates report file")
+  lazy val dependencyUpdatesExclusions = settingKey[ModuleFilter]("Dependencies that are excluded from update reporting")
   lazy val dependencyUpdatesFailBuild = settingKey[Boolean]("Fail a build if updates found")
   lazy val dependencyUpdatesData = taskKey[Map[ModuleID, SortedSet[Version]]]("")
   lazy val dependencyUpdates = taskKey[Unit]("Shows a list of project dependencies that can be updated.")

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -12,6 +12,7 @@ object UpdatesPlugin extends AutoPlugin with UpdatesPluginTasks {
 
   override val projectSettings = Seq(
     dependencyUpdatesReportFile := target.value / "dependency-updates.txt",
+    dependencyUpdatesExclusions := DependencyFilter.fnToModuleFilter(_ => false),
     dependencyUpdatesFailBuild := false,
     dependencyUpdatesData <<= dependencyUpdatesDataTask,
     dependencyUpdates <<= dependencyUpdatesTask,

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPluginTasks.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPluginTasks.scala
@@ -10,11 +10,11 @@ trait UpdatesPluginTasks {
       .map(Reporter.dependencyUpdatesData)
 
   def dependencyUpdatesTask =
-    (projectID, dependencyUpdatesData, dependencyUpdatesFailBuild, streams)
+    (projectID, dependencyUpdatesData, dependencyUpdatesExclusions, dependencyUpdatesFailBuild, streams)
       .map(Reporter.displayDependencyUpdates)
 
   def writeDependencyUpdatesReportTask =
-    (projectID, dependencyUpdatesData, dependencyUpdatesReportFile, streams)
+    (projectID, dependencyUpdatesData, dependencyUpdatesExclusions, dependencyUpdatesReportFile, streams)
       .map(Reporter.writeDependencyUpdatesReport)
 
 }


### PR DESCRIPTION
This is a reworked version of #40 that uses `ModuleFilter` as suggested by @rtimush.
