### PR TITLE
Recognize Final and Release as release version qualifieres

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
@@ -23,8 +23,10 @@ case class InvalidVersion(text: String) extends Version {
 }
 
 object ReleaseVersion {
+  val releaseKeyword = "(?i)final|release".r
   def unapply(v: Version) = v match {
     case ValidVersion(_, releasePart, Nil, Nil) => Some(releasePart)
+    case ValidVersion(_, releasePart, releaseKeyword() :: Nil, Nil) => Some(releasePart)
     case _ => None
   }
 }

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -6,9 +6,11 @@ class VersionSpec extends FreeSpec with Matchers {
 
   "Versions" - {
     "should be classified correctly" in {
-      Version("1.0.0") match {
-        case ReleaseVersion(r) => r should equal(1 :: 0 :: 0 :: Nil)
-        case _ => fail("not a release version")
+      List("1.0.0", "1.0.0.Final", "1.0.0-FINAL", "1.0.0.RELEASE") foreach { rel =>
+        Version(rel) match {
+          case ReleaseVersion(r) => r should equal(1 :: 0 :: 0 :: Nil)
+          case _ => fail(s"$rel is not a release version")
+        }
       }
       Version("1.0.0-alpha.1") match {
         case PreReleaseVersion(r, p) =>


### PR DESCRIPTION
This resolves some parts of #19:
- 0.8.0.RELEASE -> 0.8.0-rc3
- 3.10-FINAL -> 3.10-beta2