### PR TITLE
make the MetaloaderFactory more resilient

### DIFF
--- a/src/test/scala/com/timushev/sbt/updates/MetadataLoaderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/MetadataLoaderSpec.scala
@@ -1,0 +1,16 @@
+package com.timushev.sbt.updates
+
+import org.scalatest.{Matchers, FreeSpec}
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class MetadataLoaderSpec extends FreeSpec with Matchers {
+  "The metadata loader factory" - {
+    "for a broken url" - {
+      val logger = new MockLogger()
+      "should return a none" in {
+        Await.result(MetadataLoaderFactory.download(logger)("s3://somebucket"), 1.minute) should be('empty)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/timushev/sbt/updates/MockLogger.scala
+++ b/src/test/scala/com/timushev/sbt/updates/MockLogger.scala
@@ -1,0 +1,9 @@
+package com.timushev.sbt.updates
+
+import sbt.Level
+
+class MockLogger extends sbt.Logger {
+  override def trace(t: => Throwable): Unit = ()
+  override def log(level: Level.Value, message: => String): Unit = ()
+  override def success(message: => String): Unit = ()
+}


### PR DESCRIPTION
On a project I use the s3-resolver for sbt:
https://github.com/frugalmechanic/fm-sbt-s3-resolver

Unfortunately it has just a dummy implementation for the url handler.

So the plugin dies when trying downloading artifacts from s3.