### PR TITLE
Update README: show detail for versions in the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Publishing
 
 Example
 =======
+
+In order from left, the result shows current version, patch update version, minor update version and major update version.
+
 ```
 > dependencyUpdates
 [info] Found 3 dependency updates for test-project


### PR DESCRIPTION
For example, 

```
> dependencyUpdates
[info] Found 3 dependency updates for test-project
[info]   ch.qos.logback:logback-classic : 0.8   -> 0.8.1 -> 0.9.30 -> 1.0.13
[info]   org.scala-lang:scala-library   : 2.9.1 -> 2.9.3 -> 2.10.3
[info]   org.slf4j:slf4j-api            : 1.6.4 -> 1.6.6 -> 1.7.5
```

We can see version updates, but we can't know which the versions are current version, patch update version, minor update version or major update version.