### PR TITLE
Add feature: sbt upgradeBuildFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ Tasks
 =====
 * `dependencyUpdates`: show a list of project dependencies that can be updated,
 * `dependencyUpdatesReport`: writes a list of project dependencies to a file.
+* `upgradeBuildFile`: upgrade build file.
 
 Settings
 ========
 * `dependencyUpdatesReportFile`: report file location, `target/dependency-updates.txt` by default.
+* `dependencyUpgradeBuildFile`: build file location, `build.sbt` by default.
 * `dependencyUpdatesExclusions`: filter matching dependencies that should be excluded from update reporting.
 * `dependencyUpdatesFailBuild`: `dependencyUpdates` task will fail a build if updates found.
 * `dependencyAllowPreRelease`: when enabled, pre-release dependencies will be reported as well.

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
@@ -7,12 +7,14 @@ import scala.collection.immutable.SortedSet
 
 trait UpdatesKeys {
   lazy val dependencyUpdatesReportFile = settingKey[File]("Dependency updates report file")
+  lazy val dependencyUpgradeBuildFile = settingKey[File]("Build file to upgrade dependency updates")
   lazy val dependencyUpdatesExclusions = settingKey[ModuleFilter]("Dependencies that are excluded from update reporting")
   lazy val dependencyUpdatesFailBuild = settingKey[Boolean]("Fail a build if updates found")
   lazy val dependencyAllowPreRelease = settingKey[Boolean]("If true, also take pre-release versions into consideration")
   lazy val dependencyUpdatesData = taskKey[Map[ModuleID, SortedSet[Version]]]("")
   lazy val dependencyUpdates = taskKey[Unit]("Shows a list of project dependencies that can be updated.")
   lazy val dependencyUpdatesReport = taskKey[File]("Writes a list of project dependencies that can be updated to a file.")
+  lazy val upgradeBuildFile = taskKey[File]("Upgrade build file")
 }
 
 object UpdatesKeys extends UpdatesKeys

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -12,6 +12,7 @@ object UpdatesPlugin extends AutoPlugin {
 
   override val projectSettings = Seq(
     dependencyUpdatesReportFile := target.value / "dependency-updates.txt",
+    dependencyUpgradeBuildFile := baseDirectory.value / "build.sbt",
     dependencyUpdatesExclusions := DependencyFilter.fnToModuleFilter(_ => false),
     dependencyUpdatesFailBuild := false,
     dependencyAllowPreRelease := false,
@@ -23,6 +24,9 @@ object UpdatesPlugin extends AutoPlugin {
     },
     dependencyUpdatesReport := {
       Reporter.writeDependencyUpdatesReport(projectID.value, dependencyUpdatesData.value, dependencyUpdatesReportFile.value, streams.value)
+    },
+    upgradeBuildFile := {
+      Reporter.upgradeDependencyUpdates(projectID.value, dependencyUpdatesData.value, dependencyUpgradeBuildFile.value, streams.value)
     }
   )
 


### PR DESCRIPTION
I add a feature to upgrade build file.

sbt-update does not have a feature to upgrade build file just like npm-check-updates:
https://github.com/tjunnone/npm-check-updates

npm-check-updates has a feature to upgrade package.json when some packages have update.
So I wanted a feature to upgrade build file.

We can upgrade build file by `sbt upgradeBuildFile`.

Default build file is build.sbt, but there are many projects whose build file is not build.sbt. So I let them to set build file location in dependencyUpdatesReportFile.