### PR TITLE
Java 9 support

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/Base64.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Base64.scala
@@ -1,0 +1,27 @@
+package com.timushev.sbt.updates
+
+object Base64 {
+
+  private class Java678Encoder extends (Array[Byte] => String) {
+    override def apply(bytes: Array[Byte]): String =
+      javax.xml.bind.DatatypeConverter.printBase64Binary(bytes)
+  }
+
+  private class Java9Encoder extends (Array[Byte] => String) {
+    override def apply(bytes: Array[Byte]): String =
+      java.util.Base64.getEncoder.encodeToString(bytes)
+  }
+
+  private lazy val encoder: (Array[Byte]) => String = {
+    try {
+      new Java678Encoder().apply(Array.emptyByteArray)
+      new Java678Encoder
+    }
+    catch {
+      case _: LinkageError => new Java9Encoder
+    }
+  }
+
+  def encodeToString(bytes: Array[Byte]): String = encoder(bytes)
+
+}

--- a/src/main/scala/com/timushev/sbt/updates/Downloader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Downloader.scala
@@ -2,7 +2,6 @@ package com.timushev.sbt.updates
 
 import java.io.InputStream
 import java.net.URL
-import javax.xml.bind.DatatypeConverter
 
 import sbt.{Credentials, Logger}
 
@@ -14,7 +13,7 @@ class Downloader(credentials: Seq[Credentials], logger: Logger) {
     hostCredentials match {
       case Some(c) =>
         logger.debug(s"Downloading $url as ${c.userName}")
-        val auth = DatatypeConverter.printBase64Binary(s"${c.userName}:${c.passwd}".getBytes)
+        val auth = Base64.encodeToString(s"${c.userName}:${c.passwd}".getBytes)
         connection.setRequestProperty("Authorization", s"Basic $auth")
       case None =>
         logger.debug(s"Downloading $url anonymously")

--- a/src/test/scala/com/timushev/sbt/updates/Base64Spec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/Base64Spec.scala
@@ -1,0 +1,13 @@
+package com.timushev.sbt.updates
+
+import org.scalatest.FreeSpec
+
+class Base64Spec extends FreeSpec {
+
+  "Base64 encoder" - {
+    "should encode data" in {
+      assert(Base64.encodeToString(Array[Byte](1, 127)) === "AX8=")
+    }
+  }
+
+}


### PR DESCRIPTION
`javax.xml.bind.DatatypeConverter` is not available on Java 9