### PR TITLE
Expose the reporter timeout as a configurable sbt setting

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/Reporter.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Reporter.scala
@@ -23,6 +23,7 @@ object Reporter {
                             excluded: ModuleFilter,
                             included: ModuleFilter,
                             allowPreRelease: Boolean,
+                            timeout: FiniteDuration,
                             out: TaskStreams[_]): Map[ModuleID, SortedSet[Version]] = {
     val loaders = resolvers collect MetadataLoaderFactory.loader(out.log, credentials)
     val updatesFuture = Future.sequence(scalaVersions map { scalaVersion =>
@@ -34,7 +35,7 @@ object Reporter {
         updates reduce (_ intersect _)
       }
     }
-    val updates = Await.result(updatesFuture, 1.hour)
+    val updates = Await.result(updatesFuture, timeout)
     (dependencies zip updates)
       .toMap
       .transform(include(included))

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
@@ -4,6 +4,7 @@ import com.timushev.sbt.updates.versions.Version
 import sbt._
 
 import scala.collection.immutable.SortedSet
+import scala.concurrent.duration.FiniteDuration
 import com.timushev.sbt.updates.Compat._
 
 trait UpdatesKeys {
@@ -14,6 +15,7 @@ trait UpdatesKeys {
   lazy val dependencyUpdatesFilter = settingKey[ModuleFilter]("Dependencies that are included to update reporting")
   lazy val dependencyUpdatesFailBuild = settingKey[Boolean]("Fail a build if updates found")
   lazy val dependencyAllowPreRelease = settingKey[Boolean]("If true, also take pre-release versions into consideration")
+  lazy val dependencyUpdatesTimeout = settingKey[FiniteDuration]("Timeout for checking for dependency updates (defaults to 1 hour)")
   lazy val dependencyUpdatesData = taskKey[Map[ModuleID, SortedSet[Version]]]("")
   lazy val dependencyUpdates = taskKey[Unit]("Shows a list of project dependencies that can be updated.")
   lazy val dependencyUpdatesReport = taskKey[File]("Writes a list of project dependencies that can be updated to a file.")

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -1,5 +1,7 @@
 package com.timushev.sbt.updates
 
+import scala.concurrent.duration._
+
 import com.timushev.sbt.updates.UpdatesKeys._
 import sbt.Keys._
 import sbt._
@@ -17,8 +19,9 @@ object UpdatesPlugin extends AutoPlugin {
     dependencyUpdatesFilter := DependencyFilter.fnToModuleFilter(_ => true),
     dependencyUpdatesFailBuild := false,
     dependencyAllowPreRelease := false,
+    dependencyUpdatesTimeout := 1.hour,
     dependencyUpdatesData := {
-      Reporter.dependencyUpdatesData(projectID.value, libraryDependencies.value, fullResolvers.value, credentials.value, crossScalaVersions.value, dependencyUpdatesExclusions.value, dependencyUpdatesFilter.value, dependencyAllowPreRelease.value, streams.value)
+      Reporter.dependencyUpdatesData(projectID.value, libraryDependencies.value, fullResolvers.value, credentials.value, crossScalaVersions.value, dependencyUpdatesExclusions.value, dependencyUpdatesFilter.value, dependencyAllowPreRelease.value, dependencyUpdatesTimeout.value, streams.value)
     },
     dependencyUpdates := {
       Reporter.displayDependencyUpdates(projectID.value, dependencyUpdatesData.value, dependencyUpdatesFailBuild.value, streams.value)


### PR DESCRIPTION
Let's allow more flexibility when it comes to waiting for a response. `dependencyUpdatesTimeout` will allow clients to set their own timeout so that they don't have to wait for 1 hour if they don't want to. 