### PR TITLE
updating plugin to generate more machine readable outputs on the comm…

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesKeys.scala
@@ -17,6 +17,7 @@ trait UpdatesKeys {
   lazy val dependencyUpdatesData = taskKey[Map[ModuleID, SortedSet[Version]]]("")
   lazy val dependencyUpdates = taskKey[Unit]("Shows a list of project dependencies that can be updated.")
   lazy val dependencyUpdatesReport = taskKey[File]("Writes a list of project dependencies that can be updated to a file.")
+  lazy val dependencyMachineReadable = settingKey[Boolean]("If true, output the report in a CSV format")
 }
 
 object UpdatesKeys extends UpdatesKeys

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -17,14 +17,15 @@ object UpdatesPlugin extends AutoPlugin {
     dependencyUpdatesFilter := DependencyFilter.fnToModuleFilter(_ => true),
     dependencyUpdatesFailBuild := false,
     dependencyAllowPreRelease := false,
+    dependencyMachineReadable := true,
     dependencyUpdatesData := {
       Reporter.dependencyUpdatesData(projectID.value, libraryDependencies.value, fullResolvers.value, credentials.value, crossScalaVersions.value, dependencyUpdatesExclusions.value, dependencyUpdatesFilter.value, dependencyAllowPreRelease.value, streams.value)
     },
     dependencyUpdates := {
-      Reporter.displayDependencyUpdates(projectID.value, dependencyUpdatesData.value, dependencyUpdatesFailBuild.value, streams.value)
+      Reporter.displayDependencyUpdates(projectID.value, dependencyUpdatesData.value, dependencyUpdatesFailBuild.value, dependencyMachineReadable.value, streams.value)
     },
     dependencyUpdatesReport := {
-      Reporter.writeDependencyUpdatesReport(projectID.value, dependencyUpdatesData.value, dependencyUpdatesReportFile.value, streams.value)
+      Reporter.writeDependencyUpdatesReport(projectID.value, dependencyUpdatesData.value, dependencyUpdatesReportFile.value, dependencyMachineReadable.value, streams.value)
     }
   )
 


### PR DESCRIPTION
…and line. 

- I need to use this tool for some automation I'm writing. I found the output provided to be difficult to work with given that when data is not present it is simply omitted. I therefore decided to update the output so that each value omitted is clearly labeled and that the lines are comma deliimited which is more inline with other tools of this type (npm outdate, pip list --outdated, cargo outdated, mix hex.outdated).  I'm setting the default to machine readable as my assumption is that both humans and code will prefer this new format.   Here is some sample output:

```
sbt dependencyUpdates
[info] Loading settings from sbt-updates.sbt ...
[info] Loading global plugins from /Users/joe.nunnelley/.sbt/1.0/plugins
[info] Updating ProjectRef(uri("file:/Users/joe.nunnelley/.sbt/1.0/plugins/"), "global-plugins")...
[warn] Choosing local for com.timushev.sbt#sbt-updates;0.3.5-4+gc5664da-SNAPSHOT
[info] Done updating.
[info] Loading settings from dependencies.sbt,resolvers.sbt,plugins.sbt ...
[info] Loading project definition from /Users/joe.nunnelley/Documents/Socrata/git/core/project
[info] Updating ProjectRef(uri("file:/Users/joe.nunnelley/Documents/Socrata/git/core/project/"), "core-build")...
[warn] Choosing local for com.timushev.sbt#sbt-updates;0.3.5-4+gc5664da-SNAPSHOT
[info] Done updating.
[info] Loading settings from build.sbt ...
[info] Resolving key references (19982 settings) ...
[info] Set current project to core (in build file:/Users/joe.nunnelley/Documents/Socrata/git/core/)
[info] Found 1 dependency update for core
[info]    org.scala-lang:scala-library current=2.11.12,minor_update=2.12.6
[info] Found 8 dependency updates for dionysus-driver
[info]    com.googlecode.junit-toolbox:junit-toolbox:test current=2.2,minor_update=2.4
[info]    com.rojoma:rojoma-json-v3 current=3.7.2,minor_update=3.8.0
[info]    org.scala-lang:scala-library current=2.11.12,minor_update=2.12.6
[info]    org.scalacheck:scalacheck:test current=1.13.5,minor_update=1.14.0
[info]    org.scalatest:scalatest:test current=3.0.4,patch_update=3.0.5
[info]    org.slf4j:jcl-over-slf4j current=1.7.22,patch_update=1.7.25
[info]    org.slf4j:slf4j-api current=1.7.22,patch_update=1.7.25
[info]    postgresql:postgresql current=8.4-702.jdbc3,patch_update=8.4-702.jdbc4,major_update=9.4.1208-jdbc42-atlassian-hosted

```