### PR TITLE
Add plus patch version support

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
@@ -80,8 +80,11 @@ object VersionParser extends RegexParsers {
 
   private val token = """[^-+.]+""".r
   private val number = """\d{1,18}(?=[-+.]|$)""".r ^^ (_.toLong)
+  private val plusAsPatchValue = """\+""".r ^^ (_ => Long.MaxValue)
 
-  private val numericPart: Parser[List[Long]] = number ~ ("." ~> number).* ^^ { case h ~ t  => h :: t }
+  private val numericPart: Parser[List[Long]] = number ~ ("." ~> number) ~ ("." ~> (number | plusAsPatchValue)).* ^^ {
+    case h ~ m ~ t => h :: m :: t
+  }
   private val part: Parser[List[String]] = token ~ (("." | "-") ~> token).* ^^ { case h ~ t => h :: t }
 
   private val version: Parser[(List[Long], List[String], List[String])] =

--- a/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
@@ -27,7 +27,7 @@ class UpdatesFinderSpec extends FreeSpec with Matchers {
     "1.0.1-SNAPSHOT",
     "1.0.1-M3",
     "1.0.1",
-    "1.1.0",
+    "1.1.0"
   )
 
   "An updates finder" - {

--- a/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
@@ -26,7 +26,8 @@ class UpdatesFinderSpec extends FreeSpec with Matchers {
     "1.0.0",
     "1.0.1-SNAPSHOT",
     "1.0.1-M3",
-    "1.0.1"
+    "1.0.1",
+    "1.1.0",
   )
 
   "An updates finder" - {
@@ -95,39 +96,56 @@ class UpdatesFinderSpec extends FreeSpec with Matchers {
     "for stable artifacts" - {
       val u = updates("1.0.0", available, allowPreRelease = false)
       val pu = updates("1.0.0", available, allowPreRelease = true)
+      val uPlus = updates("1.0.+", available, allowPreRelease = false)
       "should not show old stable versions" in {
         u should not(contain("0.9.9"))
         pu should not(contain("0.9.9"))
+        uPlus should not(contain("0.9.9"))
       }
       "should not show old snapshots" in {
         u should not(contain("0.9.9-SNAPSHOT"))
         pu should not(contain("0.9.9-SNAPSHOT"))
+        uPlus should not(contain("0.9.9-SNAPSHOT"))
       }
       "should not show old milestones" in {
         u should not(contain("0.9.9-M3"))
         pu should not(contain("0.9.9-M3"))
+        uPlus should not(contain("0.9.9-M3"))
       }
       "should not show current snapshot" in {
         u should not(contain("1.0.0-SNAPSHOT"))
         pu should not(contain("1.0.0-SNAPSHOT"))
+        uPlus should not(contain("1.0.0-SNAPSHOT"))
       }
       "should not show current milestones" in {
         u should not(contain("1.0.0-M3"))
         pu should not(contain("1.0.0-M3"))
+        uPlus should not(contain("1.0.0-M3"))
       }
       "should show stable updates" in {
         u should contain("1.0.1")
+        u should contain("1.1.0")
         pu should contain("1.0.1")
+        pu should contain("1.1.0")
       }
       "should not show snapshot updates" in {
         u should not(contain("1.0.1-SNAPSHOT"))
         pu should not(contain("1.0.1-SNAPSHOT"))
+        uPlus should not(contain("1.0.1-SNAPSHOT"))
       }
       "should not show milestone updates" in {
         u should not(contain("1.0.1-M3"))
+        uPlus should not(contain("1.0.1-M3"))
       }
       "should show milestone updates when allowing pre-releases" in {
         pu should contain("1.0.1-M3")
+      }
+      "should show minor updates when using plus patch version" in {
+        uPlus should contain("1.1.0")
+      }
+      "should not show patch updates when using plus patch version" in {
+        uPlus should not(contain("1.0.0"))
+        uPlus should not(contain("1.0.1"))
       }
     }
   }

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -69,6 +69,27 @@ class VersionSpec extends FreeSpec with Matchers {
           case other                                                       => fail(other.toString)
         }
       }
+      "should parse versions like 1.0.+" in {
+        VersionParser.parse("1.0.+") match {
+          case VersionParser.Success((1 :: 0 :: Long.MaxValue :: Nil, Nil, Nil), _) =>
+          case other                                                                => fail(other.toString)
+        }
+      }
+
+      "should reject versions like 1.+.+, 1.+.0, +.0.0" in {
+        VersionParser.parse("1.+.+") match {
+          case VersionParser.Failure(_, _) =>
+          case other                       => fail(other.toString)
+        }
+        VersionParser.parse("1.+.0") match {
+          case VersionParser.Failure(_, _) =>
+          case other                       => fail(other.toString)
+        }
+        VersionParser.parse("+.0.0") match {
+          case VersionParser.Failure(_, _) =>
+          case other                       => fail(other.toString)
+        }
+      }
       "should parse versions like 1.0.3m" in {
         VersionParser.parse("1.0.3m") match {
           case VersionParser.Success((1 :: 0 :: Nil, "3m" :: Nil, Nil), _) =>


### PR DESCRIPTION
Hello Roman,
here is my trial to add support for accepting plus symbol as a patch version. I used `Long.MaxValue` to represent plus symbol, so that I didn't have to change the VersionOrdering :sweat_smile: . I also added tests to both `VersionSpec` and `UpdatesFinderSpec` to cover these cases.

Cheers :)