### PR TITLE
Change the ordering of pre-release identifiers

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
@@ -6,13 +6,13 @@ class VersionOrdering extends Ordering[Version] {
 
   private val subParts = "(\\d+)?(\\D+)?".r
 
-  private def parsePart(s: String): Seq[Either[Int, String]] =
+  private def parsePart(s: String): Seq[Either[BigInt, String]] =
     try {
       subParts
         .findAllIn(s)
         .matchData
         .flatMap {
-          case Groups(num, str) => Seq(Option(num).map(_.toInt).map(Left.apply), Option(str).map(Right.apply))
+          case Groups(num, str) => Seq(Option(num).map(BigInt.apply).map(Left.apply), Option(str).map(Right.apply))
         }
         .flatten
         .toList
@@ -31,10 +31,23 @@ class VersionOrdering extends Ordering[Version] {
           case (Left(x), Left(y))   => x.compareTo(y)
           case (Left(_), Right(_))  => -1
           case (Right(_), Left(_))  => 1
-          case (Right(x), Right(y)) => x.compareTo(y)
+          case (Right(x), Right(y)) => compareIdentifiers(x, y)
         }
         .find(0 != _)
         .orElse(Some(a.compareTo(b)))
+  }
+
+  private def compareIdentifiers(a: String, b: String): Int = {
+    def order(s: String): Int = s.toUpperCase match {
+      case "SNAP" | "SNAPSHOT" => -5
+      case "ALPHA"             => -4
+      case "BETA"              => -3
+      case "M"                 => -2
+      case "RC"                => -1
+      case _                   => 0
+    }
+    val (oa, ob) = (order(a), order(b))
+    if (oa < 0 || ob < 0) oa.compareTo(ob) else a.compareTo(b)
   }
 
   private def compareNumericParts(a: List[Long], b: List[Long]): Option[Int] = (a, b) match {

--- a/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/VersionOrdering.scala
@@ -28,7 +28,7 @@ class VersionOrdering extends Ordering[Version] {
       parsePart(a)
         .zip(parsePart(b))
         .map {
-          case (Left(x), Left(y))   => x.compareTo(y)
+          case (Left(x), Left(y))   => x.compare(y)
           case (Left(_), Right(_))  => -1
           case (Right(_), Left(_))  => 1
           case (Right(x), Right(y)) => compareIdentifiers(x, y)

--- a/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/UpdatesFinderSpec.scala
@@ -43,11 +43,11 @@ class UpdatesFinderSpec extends FreeSpec with Matchers {
       "should not show old snapshots" in {
         u should not(contain("0.9.9-SNAPSHOT"))
       }
-      "should not show current milestones" in {
-        u should not(contain("1.0.0-M3"))
-      }
       "should not show current snapshot" in {
         u should not(contain("1.0.0-SNAPSHOT"))
+      }
+      "should show current milestones" in {
+        u should contain("1.0.0-M3")
       }
       "should show stable updates" in {
         u should contain("1.0.0").and(contain("1.0.1"))

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -51,16 +51,23 @@ class VersionSpec extends FreeSpec with Matchers {
         "2.0.M6-SNAP9",
         "2.0.M6-SNAP23",
         "2.0.M6-SNAP23a"
-      ).map(Version.apply)
-      val pairs = v.tails.flatMap {
-        case h :: t => t.map((h, _))
-        case Nil    => List.empty
-      }
-      pairs.foreach {
-        case (a, b) =>
-          a should be < b
-          b should be > a
-      }
+      )
+      checkPairwise(v)
+    }
+    "snapshot versions are correctly ordered" in {
+      val versions = List(
+        "3.0.8",
+        "3.1.0-SNAP6",
+        "3.1.0-SNAP13",
+        "3.1.0-alpha",
+        "3.1.0-M2",
+        "3.1.0-RC",
+        "3.1.0-RC1",
+        "3.1.0-RC2",
+        "3.1.0",
+        "3.2.0-SNAPSHOT1"
+      )
+      checkPairwise(versions)
     }
     "parser" - {
       "should parse versions like 1.0.M3" in {
@@ -109,4 +116,15 @@ class VersionSpec extends FreeSpec with Matchers {
     }
   }
 
+  def checkPairwise(versions: List[String]): Unit = {
+    val pairs = versions.map(Version.apply).tails.flatMap {
+      case h :: t => t.map((h, _))
+      case Nil    => List.empty
+    }
+    pairs.foreach {
+      case (a, b) =>
+        a should be < b
+        b should be > a
+    }
+  }
 }


### PR DESCRIPTION
This changes the ordering of alphanumeric identifiers in versions so
that some identifiers are not ordered lexicographically. Identifiers
that are handled differently are: (SNAP, SNAPSHOT) < ALPHA < BETA < M < RC.
The motivation for this change is to report a version like 3.1.0-RC3
as an update for 3.1.0-SNAP13.

The change from `Int` to `BigInt` in `parsePart` has been made so that
the pre-release identifier in 1.0.0-20131213005945 is treated as numeric.
It is currently not because `"20131213005945".toInt` throws an exception.
Without this change, the version above would be greater than 1.0.0-alpha
which would lead to a test failure.

Closes #128.