### PR TITLE
Version Match Dynver Snapshots

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
@@ -50,7 +50,7 @@ object PreReleaseBuildVersion {
 
 object SnapshotVersion {
   def unapply(v: Version): Option[(List[Long], List[String], List[String])] = v match {
-    case ValidVersion(_, releasePart, preReleasePart, buildPart) if preReleasePart.lastOption == Some("SNAPSHOT") =>
+    case ValidVersion(_, releasePart, preReleasePart, buildPart) if preReleasePart.lastOption == Some("SNAPSHOT") || buildPart.lastOption == Some("SNAPSHOT") =>
       Some(releasePart, preReleasePart, buildPart)
     case _ => None
   }

--- a/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
+++ b/src/main/scala/com/timushev/sbt/updates/versions/Version.scala
@@ -50,7 +50,8 @@ object PreReleaseBuildVersion {
 
 object SnapshotVersion {
   def unapply(v: Version): Option[(List[Long], List[String], List[String])] = v match {
-    case ValidVersion(_, releasePart, preReleasePart, buildPart) if preReleasePart.lastOption == Some("SNAPSHOT") || buildPart.lastOption == Some("SNAPSHOT") =>
+    case ValidVersion(_, releasePart, preReleasePart, buildPart)
+        if preReleasePart.lastOption == Some("SNAPSHOT") || buildPart.lastOption == Some("SNAPSHOT") =>
       Some(releasePart, preReleasePart, buildPart)
     case _ => None
   }

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -31,9 +31,9 @@ class VersionSpec extends FreeSpec with Matchers {
           b should equal("build" :: "10" :: Nil)
         case _ => fail("not a build version")
       }
-      
+
       Version("2.0.2+9-4e5b95f4-SNAPSHOT") match { // Sbt-Dynver style snapshot version
-        case SnapshotVersion(r, p, b) => 
+        case SnapshotVersion(r, p, b) =>
           r should equal(2 :: 0 :: 2 :: Nil)
         case _ => fail("not a snaphshot version")
       }

--- a/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/versions/VersionSpec.scala
@@ -31,6 +31,12 @@ class VersionSpec extends FreeSpec with Matchers {
           b should equal("build" :: "10" :: Nil)
         case _ => fail("not a build version")
       }
+      
+      Version("2.0.2+9-4e5b95f4-SNAPSHOT") match { // Sbt-Dynver style snapshot version
+        case SnapshotVersion(r, p, b) => 
+          r should equal(2 :: 0 :: 2 :: Nil)
+        case _ => fail("not a snaphshot version")
+      }
     }
     "should be ordered according to the semantic versioning spec" in {
       val v = List(


### PR DESCRIPTION
Basically this enables builds to not see upgrades in these sbt-dynver style snapshot releases if the snapshot resolver is depended upon. 

Otherwise every snapshot release is seen as an upgrade.