### PR TITLE
Set homepage in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,3 +18,5 @@ scriptedLaunchOpts += s"-Dsbt.updates.version=${version.value}"
 crossSbtVersions := Seq("0.13.16", "1.1.5")
 
 scriptedSbt := Option(System.getenv("SBT_SCRIPTED_VERSION")).getOrElse((sbtVersion in pluginCrossBuild).value)
+
+homepage := Some(url("https://github.com/rtimush/sbt-updates"))


### PR DESCRIPTION
This enables Scala Steward to link to sbt-updates' homepage, version diff, and release notes, see https://twitter.com/fst9000/status/1194716047376560129.