### PR TITLE
Custom dependency positions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0

--- a/src/main/scala/com/timushev/sbt/updates/DependencyPositions.scala
+++ b/src/main/scala/com/timushev/sbt/updates/DependencyPositions.scala
@@ -1,0 +1,34 @@
+package com.timushev.sbt.updates
+
+import sbt.Keys._
+import sbt._
+
+import scala.util.control.NonFatal
+
+object DependencyPositions {
+
+  def dependencyPositionsTask: Def.Initialize[Task[Map[ModuleID, Set[SourcePosition]]]] =
+    Def.task {
+      try {
+        val projRef   = thisProjectRef.value
+        val st        = state.value
+        val sk        = libraryDependencies.in(GlobalScope.in(projRef)).scopedKey
+        val extracted = Project.extract(st)
+        val empty     = extracted.structure.data.set(sk.scope, sk.key, Nil)
+        val settings = extracted.structure.settings.filter { s =>
+          (s.key.key == libraryDependencies.key) && (s.key.scope.project == Select(projRef))
+        }
+        settings
+          .flatMap { case s: Setting[Seq[ModuleID]] @unchecked =>
+            s.init.evaluate(empty).map(_ -> s.pos)
+          }
+          .groupBy(_._1)
+          .map { case (k, v) => k -> v.map(_._2).toSet }
+      } catch {
+        case NonFatal(_) =>
+          dependencyPositions.value
+            .map { case (k, v) => k -> Set(v) }
+      }
+    }
+
+}

--- a/src/main/scala/com/timushev/sbt/updates/Reporter.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Reporter.scala
@@ -16,7 +16,6 @@ object Reporter {
   import com.timushev.sbt.updates.UpdatesFinder._
 
   def dependencyUpdatesData(
-      project: ModuleID,
       dependencies: Seq[ModuleID],
       dependenciesOverrides: Iterable[ModuleID],
       dependencyPositions: Map[ModuleID, SourcePosition],

--- a/src/main/scala/com/timushev/sbt/updates/Reporter.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Reporter.scala
@@ -18,7 +18,7 @@ object Reporter {
   def dependencyUpdatesData(
       dependencies: Seq[ModuleID],
       dependenciesOverrides: Iterable[ModuleID],
-      dependencyPositions: Map[ModuleID, SourcePosition],
+      dependencyPositions: Map[ModuleID, Set[SourcePosition]],
       resolvers: Seq[Resolver],
       credentials: Seq[Credentials],
       scalaVersions: Seq[String],
@@ -158,16 +158,25 @@ object Reporter {
 
   def excludeDependenciesFromPlugins(
       dependencies: Seq[ModuleID],
-      dependencyPositions: Map[ModuleID, SourcePosition],
+      dependencyPositions: Map[ModuleID, Set[SourcePosition]],
       buildRoot: File
   ): Seq[ModuleID] =
-    dependencies.filter { moduleId =>
-      dependencyPositions.get(moduleId) match {
-        case Some(fp: FilePosition) if fp.path.startsWith("(sbt.Classpaths") => true
-        case Some(fp: FilePosition) if fp.path.startsWith("(") =>
-          extractFileName(fp.path).exists(fileExists(buildRoot, _))
-        case _ => true
-      }
+    dependencies.filter {
+      case moduleId
+          if moduleId.organization == "org.scala-lang" &&
+            moduleId.name == "scala-library" =>
+        true
+      case moduleId =>
+        dependencyPositions.get(moduleId).fold(true) {
+          _.exists {
+            case fp: FilePosition if fp.path.startsWith("(sbt.Classpaths") =>
+              false
+            case fp: FilePosition if fp.path.startsWith("(") =>
+              extractFileName(fp.path).exists(fileExists(buildRoot, _))
+            case _ =>
+              true
+          }
+        }
     }
 
   val FileNamePattern: Regex = "^\\([^\\)]+\\) (.*)$".r

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -18,7 +18,6 @@ object UpdatesPlugin extends AutoPlugin {
     dependencyAllowPreRelease := false,
     dependencyUpdatesData := {
       Reporter.dependencyUpdatesData(
-        projectID.value,
         libraryDependencies.value,
         dependencyOverrides.value,
         dependencyPositions.value,

--- a/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
+++ b/src/main/scala/com/timushev/sbt/updates/UpdatesPlugin.scala
@@ -4,6 +4,7 @@ import com.timushev.sbt.updates.UpdatesKeys._
 import sbt.Keys._
 import sbt._
 import com.timushev.sbt.updates.Compat._
+import com.timushev.sbt.updates.DependencyPositions.dependencyPositionsTask
 
 object UpdatesPlugin extends AutoPlugin {
   object autoImport extends UpdatesKeys with Implicits
@@ -20,7 +21,7 @@ object UpdatesPlugin extends AutoPlugin {
       Reporter.dependencyUpdatesData(
         libraryDependencies.value,
         dependencyOverrides.value,
-        dependencyPositions.value,
+        dependencyPositionsTask.value,
         fullResolvers.value,
         credentials.value,
         crossScalaVersions.value,


### PR DESCRIPTION
`dependencyPositions` task is not helpful when the same dependency is declared more than once, and sbt 1.5.0 apparently changed which of the positions is used.