### PR TITLE
Support version extraction without trailing slash in link text

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/metadata/extractor/HtmlVersionExtractor.scala
+++ b/src/main/scala/com/timushev/sbt/updates/metadata/extractor/HtmlVersionExtractor.scala
@@ -6,7 +6,7 @@ import com.timushev.sbt.updates.versions.Version
 import scala.util.matching.Regex
 
 object HtmlVersionExtractor {
-  val Pattern: Regex = "<a[^>]+href=\":?([^/]*)/\"[^>]*>\\1/</a>".r
+  val Pattern: Regex = "<a[^>]+href=\":?([^/]*)/\"[^>]*>\\1/?</a>".r
 }
 
 class HtmlVersionExtractor extends VersionExtractor {


### PR DESCRIPTION
Hello! I've run into a case of an internal Nexus repository that's configured in such a way that I can only use this plugin via HTML index view URLs, and in its configuration the link text in version links doesn't include a trailing slash.

I've confirmed that the change here (which simply allows the slash to be missing) resolves the issue in my case, and it seems extremely unlikely that it would affect any other cases.