### PR TITLE
Set HTTP Accept header

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/Downloader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Downloader.scala
@@ -13,6 +13,8 @@ class Downloader(repositoryId: String, authentications: Seq[RepositoryAuthentica
     val connection         = url.openConnection()
     // Same as in org.apache.ivy.util.url.BasicURLHandler
     connection.setRequestProperty("User-Agent", s"Apache Ivy/${Ivy.getIvyVersion}")
+    // Otherwise Java sets a default that is not accepted by all remote repositories (AWS CodeArtifact as an example)
+    connection.setRequestProperty("Accept", "*/*")
     hostAuthentication match {
       case Some(c) =>
         logger.debug(s"Downloading $url as ${c.describe}")


### PR DESCRIPTION
Set a broad HTTP Accept header that prevents failures from picky remote repository implementations like AWS CodeArtifact that return a 404 if they don't like the Accept header.