### PR TITLE
Extract versions from maven html listings

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/metadata/CompoundMetadataLoader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/metadata/CompoundMetadataLoader.scala
@@ -7,9 +7,11 @@ import scala.concurrent.Future
 
 class CompoundMetadataLoader(loaders: Seq[MetadataLoader]) extends MetadataLoader {
   override def getVersions(module: sbt.ModuleID): Future[Seq[Version]] =
-    loaders.foldLeft(Future.failed[Seq[Version]](new NoSuchElementException)) { (result, loader) =>
-      result.recoverWith { case _ =>
-        loader.getVersions(module)
+    Future
+      .sequence {
+        loaders.map { loader =>
+          loader.getVersions(module).recover { case _ => Seq.empty }
+        }
       }
-    }
+      .map(_.flatten)
 }


### PR DESCRIPTION
In addition to reading `maven-metadata.xml`, try to extract versions from the html directory listing.