### PR TITLE
Remove Ivy dependency from update checks

### DIFF
--- a/src/main/scala/com/timushev/sbt/updates/Downloader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/Downloader.scala
@@ -1,7 +1,6 @@
 package com.timushev.sbt.updates
 
 import com.timushev.sbt.updates.authentication.RepositoryAuthentication
-import org.apache.ivy.Ivy
 import sbt.Logger
 
 import java.io.InputStream
@@ -11,8 +10,7 @@ class Downloader(repositoryId: String, authentications: Seq[RepositoryAuthentica
   def startDownload(url: URL): InputStream = {
     val hostAuthentication = RepositoryAuthentication.find(url.getHost, repositoryId, authentications)
     val connection         = url.openConnection()
-    // Same as in org.apache.ivy.util.url.BasicURLHandler
-    connection.setRequestProperty("User-Agent", s"Apache Ivy/${Ivy.getIvyVersion}")
+    connection.setRequestProperty("User-Agent", "sbt-updates")
     // Otherwise Java sets a default that is not accepted by all remote repositories (AWS CodeArtifact as an example)
     connection.setRequestProperty("Accept", "*/*")
     hostAuthentication match {

--- a/src/main/scala/com/timushev/sbt/updates/metadata/IvyMetadataLoader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/metadata/IvyMetadataLoader.scala
@@ -2,12 +2,10 @@ package com.timushev.sbt.updates.metadata
 
 import java.io.FileNotFoundException
 import java.net.URI
-import java.util
 
 import com.timushev.sbt.updates.Downloader
 import com.timushev.sbt.updates.metadata.extractor.HtmlVersionExtractor
 import com.timushev.sbt.updates.versions.Version
-import org.apache.ivy.core.IvyPatternHelper
 import sbt.{IO, ModuleID, URLRepository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -24,22 +22,12 @@ class IvyMetadataLoader(repo: URLRepository, downloader: Downloader) extends Met
     Future.sequence(prefixes.map(download)).map(_.flatten.flatMap(extractVersions))
   }
 
-  private def getRevisionPrefix(pattern: String, module: ModuleID): Option[String] = {
-    val tokens       = new util.HashMap[String, String]()
-    val organization =
-      if (repo.patterns.isMavenCompatible) module.organization.replace('.', '/')
-      else module.organization
-    tokens.put(IvyPatternHelper.ORGANISATION_KEY, organization)
-    tokens.put(IvyPatternHelper.ORGANISATION_KEY2, organization)
-    tokens.put(IvyPatternHelper.MODULE_KEY, module.name)
-    module.configurations.foreach(tokens.put(IvyPatternHelper.CONF_KEY, _))
-    module.extraAttributes.foreach { case (k, v) => tokens.put(removeE(k), v) }
-    val substituted = IvyPatternHelper.substituteTokens(pattern, tokens)
-    if (IvyPatternHelper.getFirstToken(substituted) == IvyPatternHelper.REVISION_KEY)
-      Some(IvyPatternHelper.getTokenRoot(substituted))
-    else
-      None
-  }
+  private def getRevisionPrefix(pattern: String, module: ModuleID): Option[String] =
+    RepositoryPattern.revisionPrefix(
+      pattern,
+      module,
+      if (repo.patterns.isMavenCompatible) module.organization.replace('.', '/') else module.organization
+    )
 
   private def download(url: String): Future[Option[String]] =
     Future {
@@ -53,6 +41,4 @@ class IvyMetadataLoader(repo: URLRepository, downloader: Downloader) extends Met
   private def extractVersions(data: String): Seq[Version] =
     IvyMetadataLoader.VersionExtractor.applyOrElse(data, (_: String) => Nil)
 
-  private def removeE(s: String): String =
-    if (s.startsWith("e:")) s.substring(2) else s
 }

--- a/src/main/scala/com/timushev/sbt/updates/metadata/MavenMetadataLoader.scala
+++ b/src/main/scala/com/timushev/sbt/updates/metadata/MavenMetadataLoader.scala
@@ -1,11 +1,9 @@
 package com.timushev.sbt.updates.metadata
 
 import java.net.URI
-import java.util
 
 import com.timushev.sbt.updates.Downloader
 import com.timushev.sbt.updates.versions.Version
-import org.apache.ivy.core.IvyPatternHelper
 import sbt.{ModuleID, URLRepository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -23,20 +21,10 @@ class MavenMetadataLoader(repo: URLRepository, downloader: Downloader) extends M
       )
       .map(_.flatten)
 
-  private def url(pattern: String, module: ModuleID): Option[String] = {
-    val tokens = new util.HashMap[String, String]()
-    val org    = module.organization.split("\\.").mkString("/")
-    tokens.put(IvyPatternHelper.ORGANISATION_KEY, org)
-    tokens.put(IvyPatternHelper.ORGANISATION_KEY2, org)
-    tokens.put(IvyPatternHelper.MODULE_KEY, module.name)
-    module.configurations.foreach(tokens.put(IvyPatternHelper.CONF_KEY, _))
-    module.extraAttributes.foreach { case (k, v) => tokens.put(removeE(k), v) }
-    val substituted = IvyPatternHelper.substituteTokens(pattern, tokens)
-    if (IvyPatternHelper.getFirstToken(substituted) == IvyPatternHelper.REVISION_KEY)
-      Some(IvyPatternHelper.getTokenRoot(substituted)).map(_ + "maven-metadata.xml")
-    else
-      None
-  }
+  private def url(pattern: String, module: ModuleID): Option[String] =
+    RepositoryPattern
+      .revisionPrefix(pattern, module, module.organization.split("\\.").mkString("/"))
+      .map(_ + "maven-metadata.xml")
 
   def extractVersions(metadata: xml.Elem): Seq[Version] =
     (metadata \ "versioning" \ "versions" \ "version").map(_.text).map(Version.apply)
@@ -46,6 +34,4 @@ class MavenMetadataLoader(repo: URLRepository, downloader: Downloader) extends M
       XML.load(downloader.startDownload(new URI(url).toURL))
     }
 
-  private def removeE(s: String): String =
-    if (s.startsWith("e:")) s.substring(2) else s
 }

--- a/src/main/scala/com/timushev/sbt/updates/metadata/RepositoryPattern.scala
+++ b/src/main/scala/com/timushev/sbt/updates/metadata/RepositoryPattern.scala
@@ -1,0 +1,63 @@
+package com.timushev.sbt.updates.metadata
+
+import sbt.ModuleID
+
+private[metadata] object RepositoryPattern {
+  def revisionPrefix(pattern: String, module: ModuleID, organization: String): Option[String] = {
+    val tokens = Map("organisation" -> organization, "organization" -> organization, "module" -> module.name) ++
+      module.configurations.map("conf" -> _) ++
+      module.extraAttributes.map { case (key, value) => key.stripPrefix("e:") -> value }
+    val substituted = substitute(pattern, tokens)
+    val first       = substituted.indexOf('[')
+    if (
+      first >= 0 && substituted.indexOf(']', first) >= 0 &&
+      substituted.substring(first + 1, substituted.indexOf(']', first)) == "revision"
+    ) {
+      val optional = substituted.indexOf('(')
+      Some(substituted.substring(0, if (optional >= 0) math.min(first, optional) else first))
+    } else None
+  }
+
+  private[metadata] def substitute(pattern: String, tokens: Map[String, String]): String = {
+    val result                            = new StringBuilder
+    val optional                          = new StringBuilder
+    var inOptional                        = false
+    var keepOptional: Option[Boolean]     = None
+    var index                             = 0
+    def append(value: String): Unit       = if (inOptional) optional.append(value) else result.append(value)
+    def invalid(message: String): Nothing = throw new IllegalArgumentException(message + " in pattern " + pattern)
+    while (index < pattern.length) {
+      pattern.charAt(index) match {
+        case '(' =>
+          if (inOptional) invalid("invalid start of optional part")
+          inOptional = true
+          optional.clear()
+          keepOptional = None
+        case ')' =>
+          if (!inOptional) invalid("invalid end of optional part")
+          inOptional = false
+          keepOptional match {
+            case Some(true) => result.append(optional)
+            case None       => result.append('(').append(optional).append(')')
+            case _          => ()
+          }
+        case '[' =>
+          val end = pattern.indexOf(']', index + 1)
+          if (end < 0) invalid("last token hasn't been closed")
+          val token = pattern.substring(index + 1, end)
+          if (token.contains('[')) invalid("invalid start of token")
+          val value = tokens.get(token)
+          if (inOptional) {
+            keepOptional = Some(value.exists(_.nonEmpty))
+            append(value.getOrElse("null"))
+          } else append(value.getOrElse(pattern.substring(index, end + 1)))
+          index = end
+        case ']'  => invalid("invalid end of token")
+        case char => append(char.toString)
+      }
+      index += 1
+    }
+    if (inOptional) invalid("optional part hasn't been closed")
+    result.toString
+  }
+}

--- a/src/test/scala/com/timushev/sbt/updates/DownloaderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/DownloaderSpec.scala
@@ -1,0 +1,46 @@
+package com.timushev.sbt.updates
+
+import java.io.ByteArrayInputStream
+import java.net.{URL, URLConnection, URLStreamHandler}
+
+import com.timushev.sbt.updates.authentication.RepositoryAuthentication
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.ConsoleLogger
+
+class DownloaderSpec extends AnyFreeSpec with Matchers {
+  "Downloader" - {
+    "identify the plugin while preserving repository headers and authentication" in {
+      var connection: URLConnection = null
+      val url                       = new URL(
+        null,
+        "https://repo.example/metadata",
+        new URLStreamHandler {
+          override def openConnection(url: URL): URLConnection = {
+            connection = new URLConnection(url) {
+              override def connect(): Unit = ()
+              override def getInputStream  = new ByteArrayInputStream(Array[Byte](42))
+            }
+            connection
+          }
+        }
+      )
+      val authentication = RepositoryAuthentication(
+        Some("repository"),
+        None,
+        None,
+        "user",
+        "password",
+        Seq("X-Repository-Token" -> "token")
+      )
+      val downloader = new Downloader("repository", Seq(authentication), ConsoleLogger())
+      val stream     = downloader.startDownload(url)
+      try stream.read() shouldBe 42
+      finally stream.close()
+      connection.getRequestProperty("User-Agent") shouldBe "sbt-updates"
+      connection.getRequestProperty("Accept") shouldBe "*/*"
+      connection.getRequestProperty("Authorization") shouldBe "Basic dXNlcjpwYXNzd29yZA=="
+      connection.getRequestProperty("X-Repository-Token") shouldBe "token"
+    }
+  }
+}

--- a/src/test/scala/com/timushev/sbt/updates/metadata/MetadataLoaderSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/metadata/MetadataLoaderSpec.scala
@@ -1,0 +1,64 @@
+package com.timushev.sbt.updates.metadata
+
+import java.io.ByteArrayInputStream
+import java.net.{URI, URL}
+import java.nio.charset.StandardCharsets.UTF_8
+
+import com.timushev.sbt.updates.Downloader
+import com.timushev.sbt.updates.versions.Version
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.{ConsoleLogger, ModuleID, Patterns, Resolver}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class MetadataLoaderSpec extends AnyFreeSpec with Matchers {
+  private val module = ModuleID("org.example", "sample", "1.0")
+  private val root   = new URI("https://repo.example/").toURL
+
+  private def downloader(expectedUrl: String, response: String) = new Downloader("test", Nil, ConsoleLogger()) {
+    override def startDownload(url: URL) = {
+      url.toString shouldBe expectedUrl
+      new ByteArrayInputStream(response.getBytes(UTF_8))
+    }
+  }
+
+  "Metadata loaders" - {
+    "fetch Maven metadata and return its available versions" in {
+      val repo   = Resolver.url("test", root)(Resolver.mavenStylePatterns)
+      val loader = new MavenMetadataLoader(
+        repo,
+        downloader(
+          "https://repo.example/org/example/sample/maven-metadata.xml",
+          "<metadata><versioning><versions><version>1.0</version><version>2.0</version></versions></versioning></metadata>"
+        )
+      )
+      Await.result(loader.getVersions(module), 5.seconds) shouldBe Seq(Version("1.0"), Version("2.0"))
+    }
+    "fetch Ivy directory listings with optional cross-version attributes" in {
+      val repo = Resolver.url("test", root)(
+        Patterns(
+          "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[artifact].[ext]"
+        ).withIsMavenCompatible(false)
+      )
+      val loader = new IvyMetadataLoader(
+        repo,
+        downloader(
+          "https://repo.example/org.example/sample/scala_3/",
+          "<html><a href=\"1.0/\">1.0/</a><a href=\"2.0/\">2.0/</a></html>"
+        )
+      )
+      Await.result(loader.getVersions(module.extra("scalaVersion" -> "3")), 5.seconds) shouldBe
+        Seq(Version("1.0"), Version("2.0"))
+    }
+    "skip patterns with unresolved attributes before the revision without downloading" in {
+      val repo   = Resolver.url("test", root)(Patterns("[unknown]/[revision]/[artifact]"))
+      val unused = new Downloader("test", Nil, ConsoleLogger()) {
+        override def startDownload(url: URL) = fail("Unexpected download: " + url)
+      }
+      for (loader <- Seq(new MavenMetadataLoader(repo, unused), new IvyMetadataLoader(repo, unused)))
+        Await.result(loader.getVersions(module), 5.seconds) shouldBe empty
+    }
+  }
+}

--- a/src/test/scala/com/timushev/sbt/updates/metadata/RepositoryPatternSpec.scala
+++ b/src/test/scala/com/timushev/sbt/updates/metadata/RepositoryPatternSpec.scala
@@ -1,0 +1,77 @@
+package com.timushev.sbt.updates.metadata
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.ModuleID
+
+class RepositoryPatternSpec extends AnyFreeSpec with Matchers {
+  private val module = ModuleID("org.example", "sample", "1.0")
+
+  "Repository patterns" - {
+    "locate revisions in Maven and Ivy layouts with either organization spelling" in {
+      for (organization <- Seq("organisation", "organization")) {
+        val pattern = s"https://repo/[$organization]/[module]/[revision]/[artifact].[ext]"
+        RepositoryPattern.revisionPrefix(pattern, module, "org/example") shouldBe Some(
+          "https://repo/org/example/sample/"
+        )
+        RepositoryPattern.revisionPrefix(pattern, module, module.organization) shouldBe Some(
+          "https://repo/org.example/sample/"
+        )
+      }
+    }
+    "substitute configuration and extra attributes, including overrides" in {
+      val configured = module.withConfigurations(Some("compile")).extra("scalaVersion" -> "3", "module" -> "override")
+      RepositoryPattern.revisionPrefix(
+        "https://repo/[module]/[conf]/scala_[scalaVersion]/[revision]/[artifact]",
+        configured,
+        configured.organization
+      ) shouldBe Some("https://repo/override/compile/scala_3/")
+    }
+    "only accept revision as the first unresolved token" in {
+      for (pattern <- Seq("[artifact]/[revision]", "[conf]/[revision]", "fixed/path", "([revision])/file"))
+        RepositoryPattern.revisionPrefix(pattern, module, module.organization) shouldBe None
+      RepositoryPattern.revisionPrefix("release-[revision]/file", module, module.organization) shouldBe Some("release-")
+    }
+    "preserve the token root before a literal optional section" in {
+      RepositoryPattern.revisionPrefix("https://repo/(literal)/[revision]", module, module.organization) shouldBe Some(
+        "https://repo/"
+      )
+    }
+    "match Ivy optional token substitution semantics" in {
+      val tokens   = Map("module" -> "sample", "empty" -> "")
+      val examples = Seq(
+        "[module]/[revision]"          -> "sample/[revision]",
+        "(scala_[missing]/)[revision]" -> "[revision]",
+        "([empty])/x"                  -> "/x",
+        "(prefix-[module])/x"          -> "prefix-sample/x",
+        "(literal)/x"                  -> "(literal)/x",
+        "([missing]-[module])/x"       -> "null-sample/x",
+        "([module]-[missing])/x"       -> "/x",
+        "([empty][module])/x"          -> "sample/x",
+        "([module][empty])/x"          -> "/x",
+        "[]/[revision]"                -> "[]/[revision]"
+      )
+      examples.foreach { case (pattern, expected) =>
+        withClue(pattern)(RepositoryPattern.substitute(pattern, tokens) shouldBe expected)
+      }
+    }
+    "leave replacement values literal" in {
+      RepositoryPattern.substitute("[module]/[revision]", Map("module" -> "$1\\name")) shouldBe "$1\\name/[revision]"
+    }
+    "handle token delimiters introduced by replacement values" in {
+      RepositoryPattern.revisionPrefix("[module]/fixed", module.withName("a["), module.organization) shouldBe None
+      RepositoryPattern.revisionPrefix("[module]/[revision]", module.withName("a("), module.organization) shouldBe Some(
+        "a"
+      )
+      RepositoryPattern.revisionPrefix(
+        "[module]/[revision]",
+        module.withName("a[unknown]"),
+        module.organization
+      ) shouldBe None
+    }
+    "reject malformed patterns" in {
+      for (pattern <- Seq("[[module]]", "[module", "module]", "((x))", "(x", "x)"))
+        withClue(pattern)(intercept[IllegalArgumentException](RepositoryPattern.substitute(pattern, Map.empty)))
+    }
+  }
+}


### PR DESCRIPTION
Fixes sbt/sbt#9679.

`dependencyUpdates` crashes on sbt 2.1.0-SNAPSHOT because sbt-updates uses Ivy classes that sbt no longer supplies after sbt/sbt#9615. Replace Ivy's repository-pattern substitution and revision-prefix extraction with a shared private helper used by both metadata loaders. Also use a plugin-specific HTTP user agent instead of querying Ivy's version.

Validation:
- New unit tests test the correctness of repository pattern-substitution and revision-prefix extraction. They cover revision prefixes, optional sections, extra attributes, malformed patterns, metadata URLs/version extraction, and HTTP headers/authentication.
- Locally, `updates/auto` fails without the fix with `NoClassDefFoundError: org/apache/ivy/core/IvyPatternHelper` and passes with it on the same freshly published sbt 2.1.0-SNAPSHOT using an isolated Ivy-free boot directory.